### PR TITLE
Sanitize nonterminals when inducing PCFG

### DIFF
--- a/hyperparam_search.py
+++ b/hyperparam_search.py
@@ -6,7 +6,7 @@ import torch
 import yaml
 import nltk
 from collections import defaultdict
-from nltk import Nonterminal, induce_pcfg, ProbabilisticProduction
+from nltk import Nonterminal, induce_pcfg, ProbabilisticProduction, Production
 from nltk.tree import Tree
 from nltk.parse import ViterbiParser
 from viterbi import TokenLevelViterbiParser
@@ -16,30 +16,32 @@ from local_llm import LocalLLM
 import matplotlib.pyplot as plt
 import os
 
+
 def get_constituents(tree: Tree) -> set:
-    
+
     constituents = set()
     leaves_pos = {}
-    
+
     leaves = tree.leaves()
     for i, leaf in enumerate(leaves):
         for pos in tree.leaf_treepositions(i):
             leaves_pos[pos] = i
-            
+
     for position in tree.treepositions():
         if isinstance(tree[position], Tree):
-            if len(tree[position].leaves())> 1:
+            if len(tree[position].leaves()) > 1:
                 subtree = tree[position]
                 start = leaves_pos[subtree.leaf_treeposition(0)]
-                end = leaves_pos[subtree.leaf_treeposition(len(subtree.leaves())-1)] + 1
+                end = leaves_pos[subtree.leaf_treeposition(len(subtree.leaves()) - 1)] + 1
                 label = subtree.label()
                 constituents.add((label, start, end))
     return constituents
 
+
 def load_config(path: str) -> Dict[str, List[Any]]:
-    """ Load a config file in either JSON or YAML"""
-    with open(path, 'r') as f:
-        if path.endswith('.json'):
+    """Load a config file in either JSON or YAML"""
+    with open(path, "r") as f:
+        if path.endswith(".json"):
             data = json.load(f)
         else:
             data = yaml.safe_load(f)
@@ -47,34 +49,59 @@ def load_config(path: str) -> Dict[str, List[Any]]:
 
 
 def get_treebank_splits(dev_ratio: float = 0.1, test_ratio: float = 0.1) -> (List[Tree], List[Tree], List[Tree]):
-    """ Get train, dev and test splits of the NLTK Treebank corpus """
+    """Get train, dev and test splits of the NLTK Treebank corpus"""
     # Get all the trees from the NLTK Treebank corpus
     trees = list(nltk.corpus.treebank.parsed_sents())
     split_dev = int(len(trees) * (1 - dev_ratio - test_ratio))
     train_trees = trees[:split_dev]
-    dev_trees = trees[split_dev:-int(len(trees) * test_ratio)] if test_ratio else trees[split_dev:]
-    test_trees = trees[-int(len(trees) * test_ratio):] if test_ratio else []
+    dev_trees = trees[split_dev : -int(len(trees) * test_ratio)] if test_ratio else trees[split_dev:]
+    test_trees = trees[-int(len(trees) * test_ratio) :] if test_ratio else []
     return train_trees, dev_trees, test_trees
 
 
 def build_pcfg(train_trees: List[Tree]):
+    """Induce a PCFG from training trees with sanitized non-terminals."""
+
+    with open(os.path.join("grammar", "changes.json"), "r") as f:
+        special_nt_map = json.load(f)
+
+    def _format_nonterminal(nt: Nonterminal) -> Nonterminal:
+        sym = nt.symbol()
+
+        if sym.startswith("-") and sym.endswith("-") and len(sym) > 1:
+            sym = sym[1:-1]
+
+        if sym in special_nt_map:
+            sym = special_nt_map[sym]
+
+        if not (sym[0].isalnum() or sym[0] == "_"):
+            sym = "X" + sym
+
+        for char, replacement in special_nt_map.items():
+            if len(char) == 1:
+                sym = sym.replace(char, replacement)
+
+        return Nonterminal(sym)
+
     productions = []
     root_counts = defaultdict(int)
 
     for tree in train_trees:
         root_counts[tree.label()] += 1
         tree.chomsky_normal_form(horzMarkov=2)
-        productions.extend(tree.productions())
+        for prod in tree.productions():
+            lhs = _format_nonterminal(prod.lhs())
+            rhs = [_format_nonterminal(sym) if isinstance(sym, Nonterminal) else sym for sym in prod.rhs()]
+            productions.append(Production(lhs, rhs))
 
     if len(root_counts) > 1:
         start = Nonterminal("ROOT")
-        total = sum(root_counts.values())
         for lbl, cnt in root_counts.items():
-            prob = cnt / total
-            prod = ProbabilisticProduction(start, [Nonterminal(lbl)], prob=prob)
-            productions.append(prod)
+            rhs_nt = _format_nonterminal(Nonterminal(lbl))
+            for _ in range(cnt):
+                productions.append(Production(start, [rhs_nt]))
     else:
-        start = Nonterminal(next(iter(root_counts)))
+        start = _format_nonterminal(Nonterminal(next(iter(root_counts))))
 
     return induce_pcfg(start, productions)
 
@@ -85,16 +112,16 @@ def evaluate(parser: ViterbiParser, dev_trees: List[Tree], *, theta: float, voca
     total_gold_constituents = 0
     total_pred_constituents = 0
     total_correct_constituents = 0
-    
+
     for gold in dev_trees:
         sent = gold.leaves()
-        tokens = TreebankWordTokenizer().tokenize(' '.join(sent))
+        tokens = TreebankWordTokenizer().tokenize(" ".join(sent))
         print(f"Evaluating sentence: {' '.join(sent)}")
-        
+
         if theta == 1.0 and any(w not in vocab for w in tokens):
             total_time += 0.0
             continue
-            
+
         t0 = time.perf_counter()
         try:
             parsed = next(parser.parse(tokens))
@@ -103,30 +130,30 @@ def evaluate(parser: ViterbiParser, dev_trees: List[Tree], *, theta: float, voca
             print("Parsing failed")
             parsed = None
         total_time += time.perf_counter() - t0
-        
+
         # Exact match
         if parsed and parsed == gold:
             correct += 1
-        
+
         # F1 calculation
         if parsed:
             gold_constituents = get_constituents(gold)
             pred_constituents = get_constituents(parsed)
-            
+
             correct_constituents = gold_constituents.intersection(pred_constituents)
-            
+
             total_gold_constituents += len(gold_constituents)
             total_pred_constituents += len(pred_constituents)
             total_correct_constituents += len(correct_constituents)
-    
+
     # Calculate metrics
     acc = correct / len(dev_trees)
     avg_time = total_time / len(dev_trees)
-    
+
     precision = total_correct_constituents / total_pred_constituents if total_pred_constituents > 0 else 0
     recall = total_correct_constituents / total_gold_constituents if total_gold_constituents > 0 else 0
     f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0
-    
+
     return acc, avg_time, precision, recall, f1
 
 
@@ -136,24 +163,22 @@ def main(cfg_path: str):
     grammar = build_pcfg(train_trees)
 
     # Ensure results directory exists
-    os.makedirs('results', exist_ok=True)
+    os.makedirs("results", exist_ok=True)
 
     lexical_vocab = {
-        prod.rhs()[0]
-        for prod in grammar.productions()
-        if len(prod.rhs()) == 1 and isinstance(prod.rhs()[0], str)
+        prod.rhs()[0] for prod in grammar.productions() if len(prod.rhs()) == 1 and isinstance(prod.rhs()[0], str)
     }
 
     results = []
     current_model = None
     llm = None
     provider = None
-    
+
     nts = {str(p.lhs()) for p in grammar.productions()}
-    
-    for theta, model_name in itertools.product(config['data_score'], config['model']):
+
+    for theta, model_name in itertools.product(config["data_score"], config["model"]):
         print(theta)
-        
+
         if theta == 1.0:
             parser = ViterbiParser(grammar)
         else:
@@ -166,41 +191,46 @@ def main(cfg_path: str):
                 llm = LocalLLM(model_name=model_name)
                 provider = TokenLevelProbabilityProvider(llm, nts)
                 current_model = model_name
-            
+
             # Use existing provider when model hasn't changed
             parser = TokenLevelViterbiParser(grammar, provider, theta=theta)
 
         acc, avg_time, precision, recall, f1 = evaluate(parser, dev_trees, theta=theta, vocab=lexical_vocab)
-        results.append({
-            'data_score': theta, 
-            'model': model_name,
-            'accuracy': acc, 
-            'avg_inference_time': avg_time,
-            'precision': precision,
-            'recall': recall,
-            'f1': f1
-        })
+        results.append(
+            {
+                "data_score": theta,
+                "model": model_name,
+                "accuracy": acc,
+                "avg_inference_time": avg_time,
+                "precision": precision,
+                "recall": recall,
+                "f1": f1,
+            }
+        )
         print(f"Results for theta={theta}, model={model_name}:")
-        print(f"Accuracy: {acc:.4f}, Avg Inference Time: {avg_time:.4f}s, Precision: {precision:.4f}, Recall: {recall:.4f}, F1: {f1:.4f}")
+        print(
+            f"Accuracy: {acc:.4f}, Avg Inference Time: {avg_time:.4f}s, Precision: {precision:.4f}, Recall: {recall:.4f}, F1: {f1:.4f}"
+        )
 
         # Add a second plot for F1 scores
         plt.figure()
-        for model in set(r['model'] for r in results):
-            vals = sorted([r for r in results if r['model'] == model], key=lambda x: x['data_score'])
-            thetas = [r['data_score'] for r in vals]
-            f1_scores = [r['f1'] for r in vals]
-            plt.plot(thetas, f1_scores, marker='o', label=model)
+        for model in set(r["model"] for r in results):
+            vals = sorted([r for r in results if r["model"] == model], key=lambda x: x["data_score"])
+            thetas = [r["data_score"] for r in vals]
+            f1_scores = [r["f1"] for r in vals]
+            plt.plot(thetas, f1_scores, marker="o", label=model)
 
-        plt.xlabel('theta')
-        plt.ylabel('F1 Score')
+        plt.xlabel("theta")
+        plt.ylabel("F1 Score")
         plt.legend()
-        plt.savefig('results/f1_scores.png')
+        plt.savefig("results/f1_scores.png")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import argparse
-    nltk.download('treebank')
-    parser = argparse.ArgumentParser(description='Hyperparameter search for parsing')
-    parser.add_argument('--config', help='Path to YAML config file', default='configs/sample.yaml')
+
+    nltk.download("treebank")
+    parser = argparse.ArgumentParser(description="Hyperparameter search for parsing")
+    parser.add_argument("--config", help="Path to YAML config file", default="configs/sample.yaml")
     args = parser.parse_args()
     main(args.config)

--- a/provider.py
+++ b/provider.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 from typing import List, Dict, Tuple, Set, Optional
 import logging
+import os
 from nltk.grammar import Nonterminal
 import torch
 from torch.nn import functional as F
 
 from local_llm import LocalLLM
 from dataclasses import dataclass, field
+
+os.makedirs("logs", exist_ok=True)
 
 # Logger for provider events
 provider_logger = logging.getLogger("provider")
@@ -158,6 +161,9 @@ class TokenLevelProbabilityProvider:
             sorted_probs = sorted(span_probs.items(), key=lambda x: x[1], reverse=True)[:5]
             topk_results = [(nt.symbol(), p) for nt, p in sorted_probs]
             print(f"Top 5 candidates for span '{span_str}': {topk_results}")
+            provider_logger.info(
+                f"Top candidates for span '{span_str}': {topk_results}"
+            )
 
             result[(start, end)] = span_probs
             if span_probs:


### PR DESCRIPTION
## Summary
- convert special nonterminals when building a PCFG
- use `Production` for frequency counts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_687b075455bc8327808ccc51cd8a85c8