### PR TITLE
Fix memory usage in inference

### DIFF
--- a/local_llm.py
+++ b/local_llm.py
@@ -7,8 +7,8 @@ import os
 from pathlib import Path
 
 load_dotenv()
-AUTH_TOKEN = os.getenv('AUTH_TOKEN')
-HOME_DIR = os.getenv('HOME_DIR')
+AUTH_TOKEN = os.getenv("AUTH_TOKEN")
+HOME_DIR = os.getenv("HOME_DIR")
 print(HOME_DIR)
 
 
@@ -18,7 +18,6 @@ PRETRAINED_TOKENIZERS = {
     "mistral": "mistralai/Mistral-7B-Instruct-v0.3",
     "mistral-nemo": "mistralai/Mistral-Nemo-Instruct-2407",
     "gemma2-27b": "google/gemma-2-27b-it",
-    "mistral": "mistralai/Mistral-7B-Instruct-v0.3",
 }
 
 HF_MODEL_NAME_MAP = {
@@ -41,52 +40,66 @@ class LocalLLM:
 
         if self.save_local_model_dir.exists():
             self.model = AutoModelForCausalLM.from_pretrained(
-                self.save_local_model_dir,
-                device_map="auto"
+                self.save_local_model_dir, device_map="auto"
             )
         else:
             quantization_config = BitsAndBytesConfig(
-                load_in_4bit=True,
-                bnb_4bit_compute_dtype=torch.float16
+                load_in_4bit=True, bnb_4bit_compute_dtype=torch.float16
             )
-            self.model = AutoModelForCausalLM.from_pretrained(self.hf_model_path, quantization_config=quantization_config, device_map="auto", token=AUTH_TOKEN)
+            self.model = AutoModelForCausalLM.from_pretrained(
+                self.hf_model_path,
+                quantization_config=quantization_config,
+                device_map="auto",
+                token=AUTH_TOKEN,
+            )
             self.model.save_pretrained(self.save_local_model_dir)
 
         if self.save_local_tokenizers_dir.exists():
             self.tokenizer = AutoTokenizer.from_pretrained(
-                self.save_local_tokenizers_dir,
-                padding_size="left"
+                self.save_local_tokenizers_dir, padding_size="left"
             )
         else:
-            self.tokenizer = AutoTokenizer.from_pretrained(self.hf_model_path, padding_size="left", token=AUTH_TOKEN)
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                self.hf_model_path, padding_size="left", token=AUTH_TOKEN
+            )
             self.tokenizer.save_pretrained(self.save_local_tokenizers_dir)
 
+        # Ensure the model stays in inference mode to avoid unnecessary
+        # gradient allocations when parsing.
+        self.model.eval()
+        for p in self.model.parameters():
+            p.requires_grad_(False)
 
     def get_response(self, chat, max_new_tokens=1024):
         """Generate response with better JSON handling"""
-        formatted_chat = self.tokenizer.apply_chat_template(chat, tokenize=False, add_generation_prompt=True)
-        inputs = self.tokenizer(formatted_chat, return_tensors="pt", add_special_tokens=False)
+        formatted_chat = self.tokenizer.apply_chat_template(
+            chat, tokenize=False, add_generation_prompt=True
+        )
+        inputs = self.tokenizer(
+            formatted_chat, return_tensors="pt", add_special_tokens=False
+        )
         inputs = {key: tensor.to(self.model.device) for key, tensor in inputs.items()}
-        
+
         # Configure generation with stopping at closing brace
         stop_token_ids = self.tokenizer.encode("}", add_special_tokens=False)[-1:]
-        
+
         outputs = self.model.generate(
             **inputs,
             max_new_tokens=max_new_tokens,
             temperature=0.1,
             eos_token_id=stop_token_ids[0],  # Stop at closing brace
-            pad_token_id=self.tokenizer.eos_token_id
+            pad_token_id=self.tokenizer.eos_token_id,
         )
-        
-        decoded_output = self.tokenizer.decode(outputs[0][inputs["input_ids"].size(1):], skip_special_tokens=True)
-        
-        # Ensure the JSON has a closing brace
-        if not decoded_output.strip().endswith('}'):
-            decoded_output = decoded_output.strip() + '}'
-            
-        return decoded_output
 
+        decoded_output = self.tokenizer.decode(
+            outputs[0][inputs["input_ids"].size(1) :], skip_special_tokens=True
+        )
+
+        # Ensure the JSON has a closing brace
+        if not decoded_output.strip().endswith("}"):
+            decoded_output = decoded_output.strip() + "}"
+
+        return decoded_output
 
     def get_token_cnt(self, prompt):
         tokens = self.tokenizer.tokenize(prompt)

--- a/provider.py
+++ b/provider.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import List, Dict, Tuple, Set, Optional
+from typing import List, Dict, Tuple, Set
 import logging
 import os
 from nltk.grammar import Nonterminal
@@ -15,14 +15,16 @@ os.makedirs("logs", exist_ok=True)
 provider_logger = logging.getLogger("provider")
 provider_logger.setLevel(logging.INFO)
 provider_handler = logging.FileHandler("logs/provider.log")
-provider_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(message)s'))
+provider_handler.setFormatter(
+    logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+)
 provider_logger.addHandler(provider_handler)
 
 # Logger for logits events
 logits_logger = logging.getLogger("logits")
 logits_logger.setLevel(logging.INFO)
 logits_handler = logging.FileHandler("logs/logits.log")
-logits_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(message)s'))
+logits_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
 logits_logger.addHandler(logits_handler)
 
 
@@ -32,23 +34,18 @@ class _TrieNode:
     nts: List[str] = field(default_factory=list)
 
 
-    
 class TokenLevelProbabilityProvider:
     """
     Uses the LLM's token-level probabilities to calculate grammar rule probabilities.
     """
-    
+
     def __init__(
-        self, 
-        llm: LocalLLM,
-        nonterminals: Set[str],
-        *,
-        cache_size: int = 2048
-        ):
+        self, llm: LocalLLM, nonterminals: Set[str], *, cache_size: int = 2048
+    ):
 
         self._llm = llm
         self._nonterminals = nonterminals
-        
+
         # Map non-terminals to the sequence of token ids that represent them in
         # the LLM vocabulary.  Some symbols (e.g. "NP-SBJ") are tokenised into
         # multiple tokens, so we keep the full sequence to compute probabilities
@@ -56,11 +53,12 @@ class TokenLevelProbabilityProvider:
         self._nt_token_seqs = self._map_nonterminals_to_token_seqs()
         self._trie = self._build_trie()
         try:
-            self._space_token_id = self._llm.tokenizer.encode(" ", add_special_tokens=False)[0]
+            self._space_token_id = self._llm.tokenizer.encode(
+                " ", add_special_tokens=False
+            )[0]
         except Exception:
             self._space_token_id = None
 
-        
     def _map_nonterminals_to_token_seqs(self) -> Dict[str, List[int]]:
         """Map non-terminals to their corresponding token id sequences."""
         nt_token_ids: Dict[str, List[int]] = {}
@@ -68,9 +66,7 @@ class TokenLevelProbabilityProvider:
             # Add a space before the symbol to mimic generation from the model
             token_ids = self._llm.tokenizer.encode(f" {nt}", add_special_tokens=False)
             nt_token_ids[nt] = token_ids
-            provider_logger.info(
-                f"Non-terminal '{nt}' mapped to token IDs {token_ids}"
-            )
+            provider_logger.info(f"Non-terminal '{nt}' mapped to token IDs {token_ids}")
         return nt_token_ids
 
     def _build_trie(self) -> _TrieNode:
@@ -97,9 +93,12 @@ class TokenLevelProbabilityProvider:
                 results[nt] = results.get(nt, 0.0) + prob
             return results
 
-        with torch.no_grad():
+        # During parsing we only need forward activations without gradient
+        # tracking. ``torch.inference_mode`` is slightly more efficient than
+        # ``torch.no_grad`` and avoids allocating autograd buffers.
+        with torch.inference_mode():
             out = self._llm.model(context)
-            logits = out.logits[0, -1, :]        
+            logits = out.logits[0, -1, :]
         token_probs = F.softmax(logits, dim=0)
 
         total_child_prob = 0.0
@@ -108,9 +107,7 @@ class TokenLevelProbabilityProvider:
             if p <= 0:
                 continue
             total_child_prob += p
-            new_ctx = torch.cat(
-                [context, torch.tensor([[tok]], device=device)], dim=1
-            )
+            new_ctx = torch.cat([context, torch.tensor([[tok]], device=device)], dim=1)
             sub_nodes = self._predict_recursive(new_ctx, child, prob * p)
             for nt, v in sub_nodes.items():
                 results[nt] = results.get(nt, 0.0) + v
@@ -124,7 +121,7 @@ class TokenLevelProbabilityProvider:
             results[nt] = results.get(nt, 0.0) + prob * leftover
 
         return results
-    
+
     def get_span_probabilities(
         self, text: str, spans: List[Tuple[int, int]]
     ) -> Dict[Tuple[int, int], Dict[Nonterminal, float]]:
@@ -151,14 +148,17 @@ class TokenLevelProbabilityProvider:
             tokens = self._llm.tokenizer.encode(prompt, return_tensors="pt")
             device = self._llm.model.device
             span_probs_raw = self._predict_recursive(tokens.to(device), self._trie, 1.0)
-            span_probs: Dict[Nonterminal, float] = {Nonterminal(nt): p for nt, p in span_probs_raw.items()}
+            span_probs: Dict[Nonterminal, float] = {
+                Nonterminal(nt): p for nt, p in span_probs_raw.items()
+            }
             for nt, p in span_probs.items():
                 logits_logger.info(
                     f"Probability for non-terminal '{nt.symbol()}' in the span '{span_str}': {p:.8f}"
                 )
 
-       
-            sorted_probs = sorted(span_probs.items(), key=lambda x: x[1], reverse=True)[:5]
+            sorted_probs = sorted(span_probs.items(), key=lambda x: x[1], reverse=True)[
+                :5
+            ]
             topk_results = [(nt.symbol(), p) for nt, p in sorted_probs]
             print(f"Top 5 candidates for span '{span_str}': {topk_results}")
             provider_logger.info(
@@ -169,12 +169,9 @@ class TokenLevelProbabilityProvider:
             if span_probs:
                 best_nt = max(span_probs.items(), key=lambda x: x[1])[0]
                 history[(start, end)] = best_nt.symbol()
-            provider_logger.info(
-                f"Span: {span_text} probabilities: {span_probs}"
-            )
+            provider_logger.info(f"Span: {span_text} probabilities: {span_probs}")
         return result
-    
-    
+
     def set_text_and_precompute(self, tokens):
         """
         Set the current text being parsed and precompute span probabilities.
@@ -182,7 +179,7 @@ class TokenLevelProbabilityProvider:
         """
         self._text = " ".join(tokens)
         n = len(tokens)
-        
+
         # Generate all possible spans
         spans: List[Tuple[int, int]] = [
             (start, start + length)
@@ -193,52 +190,49 @@ class TokenLevelProbabilityProvider:
 
         # Get span probabilities from LLM
         self._span_probs = self.get_span_probabilities(self._text, spans)
-        
+
         return self._span_probs
-    
+
     def print_trie(self):
         """Print the structure of the trie for debugging purposes."""
+
         def _print_node(node, prefix="", token_id=None, depth=0):
-            
+
             indent = "  " * depth
             token_text = ""
             if token_id is not None:
                 try:
-                    
                     token_text = f" → '{self._llm.tokenizer.decode([token_id])}'"
-                except:
+                except Exception:
                     pass
-                
+
             print(f"{indent}├── Token: {token_id}{token_text}")
-            
+
             if node.nts:
                 nt_indent = "  " * (depth + 1)
                 print(f"{nt_indent}└── Non-terminals: {', '.join(node.nts)}")
-            
-            
+
             for token_id, child in sorted(node.children.items()):
                 _print_node(child, prefix + "  ", token_id, depth + 1)
-        
+
         print("Trie Structure:")
         print("Root")
         for token_id, child in sorted(self._trie.children.items()):
             _print_node(child, "", token_id, 1)
-    
 
 
 if __name__ == "__main__":
     from nltk.grammar import PCFG
-   
+
     with open("grammar/induced_grammar.cfg", "r") as f:
         grammar_str = f.read()
     grammar = PCFG.fromstring(grammar_str)
-    
+
     # Extract all nonterminals from the grammar
     nonterminals = {str(prod.lhs()) for prod in grammar.productions()}
-    
-    
+
     llm = LocalLLM(model_name="llama3_1-70b")
-    
+
     # logger.info(f"Creating token level probability provider with nonterminals: {nonterminals}")
     provider = TokenLevelProbabilityProvider(llm, nonterminals, cache_size=2048)
 


### PR DESCRIPTION
## Summary
- load models in evaluation mode and disable grad buffers
- use inference_mode when calling the LLM
- clean up lint issues

## Testing
- `ruff check parser/local_llm.py parser/provider.py`
- `black parser/local_llm.py parser/provider.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687be7c139b48327b87d8e89ed5089de